### PR TITLE
Noetic rosserial serviceserver

### DIFF
--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -455,8 +455,7 @@ private:
 
     if (!service_servers_.count(topic_info.topic_name)) {
       ROS_INFO("Creating service server for topic %s",topic_info.topic_name.c_str());
-      ServiceServerPtr srv(new ServiceServer(
-                                             nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2)));
+      ServiceServerPtr srv(new ServiceServer(nh_, topic_info, buffer_max, boost::bind(&Session::write_message, this, _1, _2)));
       service_servers_[topic_info.topic_name] = srv;
       callbacks_[topic_info.topic_id] = boost::bind(&ServiceServer::response_handle, srv, _1);
     }
@@ -475,8 +474,7 @@ private:
 
     if (!service_servers_.count(topic_info.topic_name)) {
       ROS_INFO("Creating service server for topic %s",topic_info.topic_name.c_str());
-      ServiceServerPtr srv(new ServiceServer(
-                                             nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2)));
+      ServiceServerPtr srv(new ServiceServer(nh_, topic_info, buffer_max, boost::bind(&Session::write_message, this, _1, _2)));
       service_servers_[topic_info.topic_name] = srv;
       callbacks_[topic_info.topic_id] = boost::bind(&ServiceServer::response_handle, srv, _1);
     }

--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -74,7 +74,7 @@ public:
   {
     active_ = false;
 
-    timeout_interval_ = boost::posix_time::milliseconds(5000);
+    timeout_interval_ = boost::posix_time::milliseconds(10000);
     attempt_interval_ = boost::posix_time::milliseconds(1000);
     require_check_interval_ = boost::posix_time::milliseconds(1000);
     ros_spin_interval_ = boost::posix_time::milliseconds(10);

--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -64,7 +64,7 @@ public:
     : socket_(io_service),
       sync_timer_(io_service),
       require_check_timer_(io_service),
-      ros_spin_timer_(io_service),
+      spinner_(2),
       async_read_buffer_(socket_, buffer_max,
                          boost::bind(&Session::read_failed, this,
                                      boost::asio::placeholders::error))
@@ -74,17 +74,7 @@ public:
     timeout_interval_ = boost::posix_time::milliseconds(5000);
     attempt_interval_ = boost::posix_time::milliseconds(1000);
     require_check_interval_ = boost::posix_time::milliseconds(1000);
-    ros_spin_interval_ = boost::posix_time::milliseconds(10);
     require_param_name_ = "~require";
-
-    nh_.setCallbackQueue(&ros_callback_queue_);
-
-    // Intermittent callback to service ROS callbacks. To avoid polling like this,
-    // CallbackQueue could in the future be extended with a scheme to monitor for
-    // callbacks on another thread, and then queue them up to be executed on this one.
-    ros_spin_timer_.expires_from_now(ros_spin_interval_);
-    ros_spin_timer_.async_wait(boost::bind(&Session::ros_spin_timeout, this,
-                                           boost::asio::placeholders::error));
   }
 
   Socket& socket()
@@ -116,12 +106,14 @@ public:
     active_ = true;
     attempt_sync();
     read_sync_header();
+
+    spinner_.start();
   }
 
   void stop()
   {
-    // Abort any pending ROS callbacks.
-    ros_callback_queue_.clear();
+    // Stop the ros::AsyncSpinner
+    spinner_.stop();
 
     // Abort active session timer callbacks, if present.
     sync_timer_.cancel();
@@ -157,22 +149,6 @@ public:
   }
 
 private:
-  /**
-   * Periodic function which handles calling ROS callbacks, executed on the same
-   * io_service thread to avoid a concurrency nightmare.
-   */
-  void ros_spin_timeout(const boost::system::error_code& error) {
-    ros_callback_queue_.callAvailable();
-
-    if (ros::ok())
-    {
-      // Call again next interval.
-      ros_spin_timer_.expires_from_now(ros_spin_interval_);
-      ros_spin_timer_.async_wait(boost::bind(&Session::ros_spin_timeout, this,
-                                             boost::asio::placeholders::error));
-    }
-  }
-
   //// RECEIVING MESSAGES ////
   // TODO: Total message timeout, implement primarily in ReadBuffer.
 
@@ -283,6 +259,13 @@ private:
     stream << msg_checksum;
 
     ROS_DEBUG_NAMED("async_write", "Sending buffer of %d bytes to client.", length);
+
+    // Will call immediately if we are already on the io_service thread. Otherwise,
+    // the request is queued up and executed on that thread.
+    socket_.get_io_service().dispatch(boost::bind(&Session::write_buffer, this, buffer_ptr));
+  }
+
+  void write_buffer(BufferPtr buffer_ptr) {
     boost::asio::async_write(socket_, boost::asio::buffer(*buffer_ptr),
           boost::bind(&Session::write_completion_cb, this, boost::asio::placeholders::error, buffer_ptr));
   }
@@ -399,6 +382,8 @@ private:
     publishers_[topic_info.topic_id] = pub;
 
     set_sync_timeout(timeout_interval_);
+
+    ROS_INFO("publisher name: %s, type: %s, id: %d", topic_info.topic_name.c_str(), topic_info.message_type.c_str(), topic_info.topic_id);
   }
 
   void setup_subscriber(ros::serialization::IStream& stream) {
@@ -410,6 +395,8 @@ private:
     subscribers_[topic_info.topic_id] = sub;
 
     set_sync_timeout(timeout_interval_);
+
+    ROS_INFO("subscirber name: %s, type: %s, id: %d", topic_info.topic_name.c_str(), topic_info.message_type.c_str(), topic_info.topic_id);
   }
 
   // When the rosserial client creates a ServiceClient object (and/or when it registers that object with the NodeHandle)
@@ -423,7 +410,7 @@ private:
     ros::serialization::Serializer<rosserial_msgs::TopicInfo>::read(stream, topic_info);
 
     if (!service_clients_.count(topic_info.topic_name)) {
-      ROS_DEBUG("Creating service client for topic %s",topic_info.topic_name.c_str());
+      ROS_INFO("Creating service client for topic %s",topic_info.topic_name.c_str());
       ServiceClientPtr srv(new ServiceClient(
         nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2)));
       service_clients_[topic_info.topic_name] = srv;
@@ -443,7 +430,7 @@ private:
     ros::serialization::Serializer<rosserial_msgs::TopicInfo>::read(stream, topic_info);
 
     if (!service_clients_.count(topic_info.topic_name)) {
-      ROS_DEBUG("Creating service client for topic %s",topic_info.topic_name.c_str());
+      ROS_INFO("Creating service client for topic %s",topic_info.topic_name.c_str());
       ServiceClientPtr srv(new ServiceClient(
         nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2)));
       service_clients_[topic_info.topic_name] = srv;
@@ -467,7 +454,7 @@ private:
     ros::serialization::Serializer<rosserial_msgs::TopicInfo>::read(stream, topic_info);
 
     if (!service_servers_.count(topic_info.topic_name)) {
-      ROS_DEBUG("Creating service server for topic %s",topic_info.topic_name.c_str());
+      ROS_INFO("Creating service server for topic %s",topic_info.topic_name.c_str());
       ServiceServerPtr srv(new ServiceServer(
                                              nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2)));
       service_servers_[topic_info.topic_name] = srv;
@@ -487,7 +474,7 @@ private:
     ros::serialization::Serializer<rosserial_msgs::TopicInfo>::read(stream, topic_info);
 
     if (!service_servers_.count(topic_info.topic_name)) {
-      ROS_DEBUG("Creating service server for topic %s",topic_info.topic_name.c_str());
+      ROS_INFO("Creating service server for topic %s",topic_info.topic_name.c_str());
       ServiceServerPtr srv(new ServiceServer(
                                              nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2)));
       service_servers_[topic_info.topic_name] = srv;
@@ -537,15 +524,13 @@ private:
   bool active_;
 
   ros::NodeHandle nh_;
-  ros::CallbackQueue ros_callback_queue_;
+  ros::AsyncSpinner spinner_; // Use 2 threads
 
   boost::posix_time::time_duration timeout_interval_;
   boost::posix_time::time_duration attempt_interval_;
   boost::posix_time::time_duration require_check_interval_;
-  boost::posix_time::time_duration ros_spin_interval_;
   boost::asio::deadline_timer sync_timer_;
   boost::asio::deadline_timer require_check_timer_;
-  boost::asio::deadline_timer ros_spin_timer_;
   std::string require_param_name_;
 
   std::map<uint16_t, boost::function<void(ros::serialization::IStream&)> > callbacks_;

--- a/rosserial_server/include/rosserial_server/topic_handlers.h
+++ b/rosserial_server/include/rosserial_server/topic_handlers.h
@@ -196,9 +196,10 @@ typedef boost::shared_ptr<ServiceClient> ServiceClientPtr;
 
 class ServiceServer {
 public:
-  ServiceServer(ros::NodeHandle& nh, rosserial_msgs::TopicInfo& topic_info,
+  ServiceServer(ros::NodeHandle& nh, rosserial_msgs::TopicInfo& topic_info, size_t capacity,
       boost::function<void(std::vector<uint8_t>& buffer, const uint16_t topic_id)> write_fn)
     : write_fn_(write_fn) {
+    response_buffer_.resize(capacity);
     topic_id_ = -1;
     get_response_ = false;
 
@@ -268,21 +269,23 @@ public:
           }
       }
 
-    response_message = response_message_;
+    ros::serialization::IStream response_stream(&response_buffer_[0], buffer_len_);
+    ros::serialization::Serializer<topic_tools::ShapeShifter>::read(response_stream, response_message);
 
     ROS_ERROR_STREAM("OK!!");
     return true;
   }
 
   void response_handle(ros::serialization::IStream stream) {
-    ros::serialization::Serializer<topic_tools::ShapeShifter>::read(stream, response_message_);
+    buffer_len_ = stream.getLength();
+    std::memcpy(&response_buffer_[0], stream.getData(),stream.getLength());
     std::cout << "service receive " << service_server_.getService() << " response" << std::endl;
     get_response_ = true;
   }
 
 private:
-  //topic_tools::ShapeShifter request_message_;
-  topic_tools::ShapeShifter response_message_;
+  std::vector<uint8_t> response_buffer_;
+  size_t buffer_len_;
   ros::ServiceServer service_server_;
   boost::function<void(std::vector<uint8_t>& buffer, const uint16_t topic_id)> write_fn_;
   std::string service_md5_;

--- a/rosserial_server/include/rosserial_server/topic_handlers.h
+++ b/rosserial_server/include/rosserial_server/topic_handlers.h
@@ -197,8 +197,8 @@ typedef boost::shared_ptr<ServiceClient> ServiceClientPtr;
 class ServiceServer {
 public:
   ServiceServer(ros::NodeHandle& nh, rosserial_msgs::TopicInfo& topic_info, size_t capacity,
-      boost::function<void(std::vector<uint8_t>& buffer, const uint16_t topic_id)> write_fn)
-    : write_fn_(write_fn) {
+      boost::function<void(std::vector<uint8_t>& buffer, const uint16_t topic_id)> write_fn, double timeout = 10)
+    : write_fn_(write_fn), timeout_(timeout) {
     response_buffer_.resize(capacity);
     topic_id_ = -1;
     get_response_ = false;
@@ -247,7 +247,7 @@ public:
   bool request_handle(topic_tools::ShapeShifter& request_message, topic_tools::ShapeShifter& response_message) {
 
     get_response_ = false;
-    ROS_ERROR_STREAM("service receive " << service_server_.getService() << " request");
+    ROS_DEBUG_STREAM("service receive " << service_server_.getService() << " request");
 
     size_t length = ros::serialization::serializationLength(request_message);
     std::vector<uint8_t> buffer(length);
@@ -257,14 +257,14 @@ public:
     write_fn_(buffer,topic_id_);
 
     //wait for the response
-    int cnt = 0;
+    ros::Time start_t = ros::Time::now();
     while(!get_response_)
       {
         ros::Duration(0.01).sleep();
 
-        if (cnt++ > 500) // hard-coding
+        if (ros::Time::now().toSec() - start_t.toSec() > timeout_)
           {
-            ROS_WARN_STREAM(service_server_.getService() << ": no response!!");
+            ROS_WARN_STREAM(service_server_.getService() << ": no response for " << timeout_ << ", give up.");
             return false;
           }
       }
@@ -272,14 +272,13 @@ public:
     ros::serialization::IStream response_stream(&response_buffer_[0], buffer_len_);
     ros::serialization::Serializer<topic_tools::ShapeShifter>::read(response_stream, response_message);
 
-    ROS_ERROR_STREAM("OK!!");
     return true;
   }
 
   void response_handle(ros::serialization::IStream stream) {
     buffer_len_ = stream.getLength();
     std::memcpy(&response_buffer_[0], stream.getData(),stream.getLength());
-    std::cout << "service receive " << service_server_.getService() << " response" << std::endl;
+    ROS_DEBUG_STREAM("service receive " << service_server_.getService() << " response");
     get_response_ = true;
   }
 
@@ -292,6 +291,7 @@ private:
   std::string request_message_md5_;
   std::string response_message_md5_;
   uint16_t topic_id_;
+  double timeout_;
 
   bool get_response_;
 };

--- a/rosserial_server/include/rosserial_server/topic_handlers.h
+++ b/rosserial_server/include/rosserial_server/topic_handlers.h
@@ -246,7 +246,7 @@ public:
   bool request_handle(topic_tools::ShapeShifter& request_message, topic_tools::ShapeShifter& response_message) {
 
     get_response_ = false;
-    ROS_DEBUG_STREAM("service receive " << service_server_.getService() << " request");
+    ROS_ERROR_STREAM("service receive " << service_server_.getService() << " request");
 
     size_t length = ros::serialization::serializationLength(request_message);
     std::vector<uint8_t> buffer(length);
@@ -276,7 +276,7 @@ public:
 
   void response_handle(ros::serialization::IStream stream) {
     ros::serialization::Serializer<topic_tools::ShapeShifter>::read(stream, response_message_);
-    ROS_DEBUG_STREAM("service receive " << service_server_.getService() << " response");
+    std::cout << "service receive " << service_server_.getService() << " response" << std::endl;
     get_response_ = true;
   }
 

--- a/rosserial_server/include/rosserial_server/topic_handlers.h
+++ b/rosserial_server/include/rosserial_server/topic_handlers.h
@@ -184,7 +184,6 @@ private:
   topic_tools::ShapeShifter request_message_;
   topic_tools::ShapeShifter response_message_;
   ros::ServiceClient service_client_;
-  static ros::ServiceClient service_info_service_;
   boost::function<void(std::vector<uint8_t>& buffer, const uint16_t topic_id)> write_fn_;
   std::string service_md5_;
   std::string request_message_md5_;
@@ -192,8 +191,109 @@ private:
   uint16_t topic_id_;
 };
 
-ros::ServiceClient ServiceClient::service_info_service_;
 typedef boost::shared_ptr<ServiceClient> ServiceClientPtr;
+
+
+class ServiceServer {
+public:
+  ServiceServer(ros::NodeHandle& nh, rosserial_msgs::TopicInfo& topic_info,
+      boost::function<void(std::vector<uint8_t>& buffer, const uint16_t topic_id)> write_fn)
+    : write_fn_(write_fn) {
+    topic_id_ = -1;
+    get_response_ = false;
+
+    rosserial_server::MsgInfo srvinfo;
+    rosserial_server::MsgInfo reqinfo;
+    rosserial_server::MsgInfo respinfo;
+    try
+    {
+      srvinfo = lookupMessage(topic_info.message_type, "srv");
+      reqinfo = lookupMessage(topic_info.message_type + "Request", "srv");
+      respinfo = lookupMessage(topic_info.message_type + "Response", "srv");
+    }
+    catch (const std::exception& e)
+    {
+      ROS_WARN_STREAM("Unable to look up service definition: " << e.what());
+    }
+
+    service_md5_ = srvinfo.md5sum;
+    request_message_md5_ = reqinfo.md5sum;
+    response_message_md5_ = respinfo.md5sum;
+
+    ros::AdvertiseServiceOptions opts;
+    opts.service = topic_info.topic_name;
+    opts.md5sum = service_md5_;
+    opts.datatype = topic_info.message_type;
+    opts.req_datatype = topic_info.message_type + "Request";
+    opts.res_datatype = topic_info.message_type + "Response";
+    opts.helper = boost::make_shared<ros::ServiceCallbackHelperT<ros::ServiceSpec<topic_tools::ShapeShifter,topic_tools::ShapeShifter> > >(boost::bind(&ServiceServer::request_handle, this, _1, _2));
+
+    service_server_ = nh.advertiseService(opts);
+  }
+  void setTopicId(uint16_t topic_id) {
+    topic_id_ = topic_id;
+  }
+  std::string getServiceMD5() {
+    return service_md5_;
+  }
+  std::string getRequestMessageMD5() {
+    return request_message_md5_;
+  }
+  std::string getResponseMessageMD5() {
+    return response_message_md5_;
+  }
+
+  bool request_handle(topic_tools::ShapeShifter& request_message, topic_tools::ShapeShifter& response_message) {
+
+    get_response_ = false;
+    ROS_DEBUG_STREAM("service receive " << service_server_.getService() << " request");
+
+    size_t length = ros::serialization::serializationLength(request_message);
+    std::vector<uint8_t> buffer(length);
+
+    ros::serialization::OStream ostream(&buffer[0], length);
+    ros::serialization::Serializer<topic_tools::ShapeShifter>::write(ostream, request_message);
+    write_fn_(buffer,topic_id_);
+
+    //wait for the response
+    int cnt = 0;
+    while(!get_response_)
+      {
+        ros::Duration(0.01).sleep();
+
+        if (cnt++ > 500) // hard-coding
+          {
+            ROS_WARN_STREAM(service_server_.getService() << ": no response!!");
+            return false;
+          }
+      }
+
+    response_message = response_message_;
+
+    ROS_ERROR_STREAM("OK!!");
+    return true;
+  }
+
+  void response_handle(ros::serialization::IStream stream) {
+    ros::serialization::Serializer<topic_tools::ShapeShifter>::read(stream, response_message_);
+    ROS_DEBUG_STREAM("service receive " << service_server_.getService() << " response");
+    get_response_ = true;
+  }
+
+private:
+  //topic_tools::ShapeShifter request_message_;
+  topic_tools::ShapeShifter response_message_;
+  ros::ServiceServer service_server_;
+  boost::function<void(std::vector<uint8_t>& buffer, const uint16_t topic_id)> write_fn_;
+  std::string service_md5_;
+  std::string request_message_md5_;
+  std::string response_message_md5_;
+  uint16_t topic_id_;
+
+  bool get_response_;
+};
+
+typedef boost::shared_ptr<ServiceServer> ServiceServerPtr;
 
 }  // namespace
 

--- a/rosserial_test/CMakeLists.txt
+++ b/rosserial_test/CMakeLists.txt
@@ -3,13 +3,17 @@ project(rosserial_test)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
+  rosserial_arduino
   rosserial_client
   rosserial_msgs
   rosserial_python
   rosserial_server
   rostest
   std_msgs
+  std_srvs
 )
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 catkin_package(
   CATKIN_DEPENDS
@@ -40,6 +44,7 @@ if(CATKIN_ENABLE_TESTING)
   endfunction()
 
   add_rosserial_test_executable(publish_subscribe)
+  add_rosserial_test_executable(service_server)
 
   add_rostest(test/rosserial_server_socket.test)
   add_rostest(test/rosserial_server_serial.test)

--- a/rosserial_test/include/rosserial_test/fixture.h
+++ b/rosserial_test/include/rosserial_test/fixture.h
@@ -74,6 +74,7 @@ public:
 
 class SingleClientFixture : public ::testing::Test {
 protected:
+  SingleClientFixture(): as(2) {}
   static void SetModeFromParam() {
     std::string mode;
     ros::param::get("~mode", mode);
@@ -90,15 +91,16 @@ protected:
     if (setup == NULL) SetModeFromParam();
     setup->SetUp();
     rosserial::ClientComms::fd = setup->fd;
+    as.start();
   }
   virtual void TearDown() {
     setup->TearDown();
+    as.stop();
   }
 
   rosserial::ros::NodeHandle client_nh;
   ros::NodeHandle nh;
+  ros::AsyncSpinner as;
   static AbstractSetup* setup;
 };
 AbstractSetup* SingleClientFixture::setup = NULL;
-
-

--- a/rosserial_test/package.xml
+++ b/rosserial_test/package.xml
@@ -21,4 +21,5 @@
   <depend>rosserial_server</depend>
   <depend>rostest</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
  </package>

--- a/rosserial_test/src/publish_subscribe.cpp
+++ b/rosserial_test/src/publish_subscribe.cpp
@@ -30,7 +30,6 @@ TEST_F(SingleClientFixture, single_publish) {
   for(int attempt = 0; attempt < 50; attempt++) {
     client_pub.publish(&string_msg);
     client_nh.spinOnce();
-    ros::spinOnce();
     if (str_callback.times_called > 0) break;
     ros::Duration(0.1).sleep();
   }
@@ -62,7 +61,6 @@ TEST_F(SingleClientFixture, single_subscribe) {
   string_msg.data = "to-rosserial-client";
   for(int attempt = 0; attempt < 50; attempt++) {
     pub.publish(string_msg);
-    ros::spinOnce();
     client_nh.spinOnce();
     if (rosserial_string_cb_count > 0) break;
     ros::Duration(0.1).sleep();

--- a/rosserial_test/src/service_server.cpp
+++ b/rosserial_test/src/service_server.cpp
@@ -1,0 +1,60 @@
+#include "ros/ros.h"
+#include "std_srvs/Empty.h"
+
+namespace rosserial {
+#include "rosserial_test/ros.h"
+#include "rosserial/std_srvs/Empty.h"
+}
+
+#include <gtest/gtest.h>
+#include "rosserial_test/fixture.h"
+#include <boost/thread.hpp>
+
+/* TODO */
+/* this test is imcomplete, since the response is not checked. */
+
+bool receive = false;
+static void callback(const rosserial::std_srvs::Empty::Request & req, rosserial::std_srvs::Empty::Response & res){
+  receive = true;
+}
+
+/**
+ * Single service call from a rosserial-connected client,
+ * verified from a roscpp rosservice server.
+ */
+TEST_F(SingleClientFixture, single_service_server) {
+
+  rosserial::ros::ServiceServer<rosserial::std_srvs::Empty::Request, rosserial::std_srvs::Empty::Response> client_server("test_srv",&callback);
+  client_nh.advertiseService(client_server);
+  client_nh.initNode();
+
+  // Roscpp rosservice client to call for the client.
+  ros::ServiceClient test_client = nh.serviceClient<std_srvs::Empty>("test_srv");
+  std_srvs::Empty srv;
+
+  for(int attempt = 0; attempt < 50; attempt++) {
+    if (attempt % 10 == 0 && attempt > 0) {
+
+      if (test_client.call(srv)) {
+        ROS_ERROR("Receive response");
+        break;
+      }
+      else {
+        ROS_ERROR("Failed to call service test_srv");
+      }
+    }
+
+    if(receive) break;
+    client_nh.spinOnce();
+    ros::Duration(0.1).sleep();
+  }
+
+  EXPECT_TRUE(receive);
+}
+
+int main(int argc, char **argv){
+  ros::init(argc, argv, "test_service_server");
+  ros::start();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rosserial_test/test/rosserial_python_serial.test
+++ b/rosserial_test/test/rosserial_python_serial.test
@@ -1,11 +1,21 @@
 <launch>
-  <node pkg="rosserial_python" type="serial_node.py" name="rosserial_python_node" args="/tmp/rosserial_pty2" output="screen">
+  <arg name="mode" default="serial" />
+  <arg name="port" default="/tmp/rosserial_pty2" />
+
+  <node pkg="rosserial_python" type="serial_node.py" name="rosserial_python_node" args="$(arg port)" output="screen">
     <param name="fix_pyserial_for_test" value="True" />
   </node>
 
   <test test-name="rosserial_python_serial_test_publish_subscribe" pkg="rosserial_test"
         type="rosserial_test_publish_subscribe" time-limit="10.0">
-    <param name="mode" value="serial" />
-    <param name="port" value="/tmp/rosserial_pty2" />
+    <param name="mode" value="$(arg mode)" />
+    <param name="port" value="$(arg port)" />
   </test>
+
+  <test test-name="rosserial_python_serial_test_service_server" pkg="rosserial_test"
+        type="rosserial_test_service_server" time-limit="10.0">
+    <param name="mode" value="$(arg mode)" />
+    <param name="port" value="$(arg port)" />
+  </test>
+
 </launch>

--- a/rosserial_test/test/rosserial_python_socket.test
+++ b/rosserial_test/test/rosserial_python_socket.test
@@ -1,9 +1,19 @@
 <launch>
-  <node pkg="rosserial_python" type="serial_node.py" name="rosserial_python_node" args="tcp 11412" />
+  <arg name="mode" default="socket" />
+  <arg name="port" default="11412" />
+
+  <node pkg="rosserial_python" type="serial_node.py" name="rosserial_python_node" args="tcp $(arg port)" />
 
   <test test-name="rosserial_python_socket_test_publish_subscribe" pkg="rosserial_test"
         type="rosserial_test_publish_subscribe" time-limit="10.0">
-    <param name="mode" value="socket" />
-    <param name="tcp_port" value="11412" />
+    <param name="mode" value="$(arg mode)" />
+    <param name="tcp_port" value="$(arg port)" />
+    </test>
+
+  <test test-name="rosserial_python_socket_test_service_server" pkg="rosserial_test"
+        type="rosserial_test_service_server" time-limit="10.0">
+    <param name="mode" value="$(arg mode)" />
+    <param name="tcp_port" value="$(arg port)" />
   </test>
+
 </launch>

--- a/rosserial_test/test/rosserial_server_serial.test
+++ b/rosserial_test/test/rosserial_server_serial.test
@@ -1,11 +1,21 @@
 <launch>
+  <arg name="mode" default="serial" />
+  <arg name="port" default="/tmp/rosserial_pty" />
+
   <include file="$(find rosserial_server)/launch/serial.launch">
-    <arg name="port" value="/tmp/rosserial_pty" />
+    <arg name="port" value="$(arg port)" />
   </include>
 
   <test test-name="rosserial_server_serial_test_publish_subscribe" pkg="rosserial_test"
         type="rosserial_test_publish_subscribe" time-limit="10.0">
-    <param name="mode" value="serial" />
-    <param name="port" value="/tmp/rosserial_pty" />
+    <param name="mode" value="$(arg mode)" />
+    <param name="port" value="$(arg port)" />
   </test>
+
+  <test test-name="rosserial_server_serial_test_service_server" pkg="rosserial_test"
+        type="rosserial_test_service_server" time-limit="10.0">
+    <param name="mode" value="$(arg mode)" />
+    <param name="port" value="$(arg port)" />
+  </test>
+
 </launch>

--- a/rosserial_test/test/rosserial_server_socket.test
+++ b/rosserial_test/test/rosserial_server_socket.test
@@ -1,12 +1,22 @@
 <launch>
+  <arg name="mode" default="socket" />
+  <arg name="port" default="11413" />
+
   <node pkg="rosserial_server" type="socket_node" name="rosserial_server">
-    <param name="port" value="11413" />
+    <param name="port" value="$(arg port)" />
   </node>
   <node pkg="rosserial_python" type="message_info_service.py" name="rosserial_message_info" />
 
   <test test-name="rosserial_server_socket_test_publish_subscribe" pkg="rosserial_test"
         type="rosserial_test_publish_subscribe" time-limit="10.0">
-    <param name="mode" value="socket" />
-    <param name="tcp_port" value="11413" />
+    <param name="mode" value="$(arg mode)" />
+    <param name="tcp_port" value="$(arg port)" />
   </test>
+
+  <test test-name="rosserial_server_socket_test_service_server" pkg="rosserial_test"
+        type="rosserial_test_service_server" time-limit="10.0">
+    <param name="mode" value="$(arg mode)" />
+    <param name="tcp_port" value="$(arg port)" />
+  </test>
+
 </launch>


### PR DESCRIPTION
Update for noetic.
Add non-busy wait loop for processing serial request.
Spin serviceservers on separate thread and callback queue.
Send ID_TX_STOP on shutdown.
Fix request-response md5 check.

Noetic merge is bit dirty.