### PR TITLE
Rosservice server condition variable wait and timing fix for rosserial_python

### DIFF
--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -433,7 +433,7 @@ private:
 
     set_sync_timeout(timeout_interval_);
 
-    ROS_INFO("subscirber name: %s, type: %s, id: %d", topic_info.topic_name.c_str(), topic_info.message_type.c_str(), topic_info.topic_id);
+    ROS_INFO("subscriber name: %s, type: %s, id: %d", topic_info.topic_name.c_str(), topic_info.message_type.c_str(), topic_info.topic_id);
   }
 
   // When the rosserial client creates a ServiceClient object (and/or when it registers that object with the NodeHandle)

--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -73,7 +73,7 @@ public:
   {
     active_ = false;
 
-    timeout_interval_ = boost::posix_time::milliseconds(5000);
+    timeout_interval_ = boost::posix_time::milliseconds(15000); // rosserial_python has 5s timeout, but sync timeout check multiplies it by three
     attempt_interval_ = boost::posix_time::milliseconds(1000);
     require_check_interval_ = boost::posix_time::milliseconds(1000);
     require_param_name_ = "~require";


### PR DESCRIPTION
Related to: https://github.com/tongtybj/rosserial/pull/4
Replace busy-wait loop with condition variable.
Fix sync timeout to match rosserial_python.
Fix typo from my original commit.

Didn't see any performance hit from async removal. Only exit with ctlr-c seems bit slower but not critical.